### PR TITLE
Add initial implementation and documentation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    # Setup pre-commit's cache
+    - name: set PY
+      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    # Run pre-commit
+    - uses: pre-commit/action@v1.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.5.0
+  hooks:
+  - id: check-added-large-files
+  - id: check-case-conflict
+  - id: check-json
+  - id: end-of-file-fixer
+  - id: forbid-new-submodules
+  - id: mixed-line-ending
+  - id: trailing-whitespace
+
+- repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21-2
+  hooks:
+  - id: isort
+    files: \.py$
+
+- repo: https://github.com/psf/black
+  rev: 19.10b0
+  hooks:
+  - id: black

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2020 Pradyun Gedam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ These tests provide a mechanism for implementations to verify that they are comp
 
 ## Usage
 
-Usage instructions, as well as other useful information about this repository can be found in the [documentation][docs/].
+Usage instructions, as well as other useful information about this repository can be found in the [documentation](docs/).
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Compliance tests for TOML
+
+Language-agnostic tests for TOML implementations, for testing compliance with the TOML specification.
+
+These tests provide a mechanism for implementations to verify that they are compliant with the TOML specification, without a "blessed" / reference implementation of TOML, to be taken as ground truth.
+
+## Usage
+
+Usage instructions, as well as other useful information about this repository can be found in the [documentation][docs/].
+
+## Acknowledgements
+
+This repository builds upon some excellent work done by:
+
+- @BurntSushi: who initially designed this test format (!), and wrote tests for TOML 0.4.0.
+- @sgarciac and @iarna: who wrote tests in this format, for TOML 0.5.0 as well as TOML 1.0.0-rc1!

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,60 @@
+# Using toml-compliance
+
+Hello there! If you're reading this, you're likely implementing/maintain a TOML parser/writer (or... you're a really curious person! go you!). Thank you for your interest in TOML!
+
+For using this compliance test suite (with included runner), with a TOML decoder / encoder (parser / writer), a [specific interface](interfaces.md) to them needs to be provided. This interface (and test files themselves) utilize a [JSON encoding](json-encoding.md) of TOML documents.
+
+## Usage
+
+> NOTE: If you're not able to use the provided runner for some technical reason, consider filing an issue. You can write your own test runner obviously, but that might be more work than necessary.
+
+`run.py` is the main entry point. It runs the provided programs using the interface described above, against various test cases, while reporting progress and providing information about failures.
+
+### Requirements
+
+You'll need Python 3.6+ to use this test runner. There are no additional dependencies for the test runner.
+
+On Windows, you may (optionally) install [colorama](https://pypi.org/project/colorama) in the environment you run this script from, to get colored output.
+
+### Running
+
+For running tests on a decoder, run:
+
+```sh-session
+$ python run.py decoder <your-decoder>
+```
+
+For running tests on an encoder, run:
+
+```sh-session
+$ python run.py encoder <your-encoder> --decoder <your-decoder>
+```
+
+The encoder tests require a specification-compliant decoder. The encoder's output is validated by decoding it, and checking if that is equivalent to the original input.
+
+### Markers
+
+For both these commands, `-m` can be used to provide "markers" which are used to filter tests based on their category (`valid` or `invalid`) or names (good choices would be `array`, `table`, `unicode`). You may provide this option multiple times. A few examples:
+
+```sh-session
+# run for all valid decoder tests
+$ python run.py decoder <your-decoder> -m valid
+# run for all invalid decoder tests, with "array" in their name
+$ python run.py decoder <your-decoder> -m array -m invalid
+# run for all decoder tests, with "table" in their name
+$ python run.py decoder <your-decoder> -m table
+```
+
+## Test Layout
+
+There are 2 kinds of tests in this repository: valid and invalid.
+
+Valid tests check that a decoder (AKA parser) accepts valid TOML documents, and an encoder represents data correctly as TOML. Each valid tests consists of two files -- a `.toml` file containing a valid TOML document and a `.json` file containing the JSON encoding of that document.
+
+Invalid tests check that a decoder rejects invalid TOML data, and an encoder rejects data that can not be represented as TOML. An invalid test consist of a single `.toml` file (invalid TOML data, decoder) or a single `.json` file (invalid JSON encoding, encoder).
+
+The tests should be small enough that writing the JSON encoding by hand will not give you brain damage. The exact reverse is true when testing encoders.
+
+### Naming
+
+Every test file should be named after the fault it is trying to expose, and ideally, each test should try to test one thing and one thing only. The names of the tests can be used as "markers" to select them, so these names should contain as much relevant context as necessary.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Hello there! If you're reading this, you're likely implementing/maintain a TOML parser/writer (or... you're a really curious person! go you!). Thank you for your interest in TOML!
 
-For using this compliance test suite (with included runner), with a TOML decoder / encoder (parser / writer), a [specific interface](interfaces.md) to them needs to be provided. This interface (and test files themselves) utilize a [JSON encoding](json-encoding.md) of TOML documents.
+For using this compliance test suite, to test a TOML decoder / encoder, a [specific interface](interfaces.md) to them needs to be provided. This interface (and test files themselves) utilize a [JSON encoding](json-encoding.md) of TOML documents.
 
 ## Usage
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,27 @@
+# Interfaces
+
+For a decoder (AKA parser) or encoder (AKA writer) to be compatible with the provided runner, they must satisfy the interface described here.
+
+They are executed in a subprocess, with additional details described below.
+
+## Decoders
+
+- Accept a TOML data on stdin until EOF.
+- For invalid TOML data:
+  - Return with a non-zero exit code.
+- For valid TOML data:
+  - Output a [JSON encoding](json-encoding.md) of the TOML data, to stdout.
+  - Return with a zero exit code.
+
+Decoders are run with all `.toml` files, with their output checked against the corresponding `.json` file (if it exists).
+
+## Encoders
+
+- Accept JSON data on stdin until EOF.
+- For JSON data that cannot be converted to a valid TOML representation:
+  - Return with a non-zero exit code.
+- For JSON data that can be converted to a valid TOML representation:
+  - Output a TOML representation of input, to stdout.
+  - Return with a zero exit code.
+
+Encoders are run with all `.json` files, with their output checked using a decoder and compared to the same `.json` file. The JSON input to a encoder is the same as, the JSON output of a decoder for the corresponding `.toml` file.

--- a/docs/json-encoding.md
+++ b/docs/json-encoding.md
@@ -43,9 +43,9 @@ The JSON encoding for the above is:
 
 ```json
 {
-  "best-day-ever": {"type": "datetime", "value": "1987-07-05T17:45:00Z"},
+  "best-day-ever": {"type": "offset datetime", "value": "1987-07-05T17:45:00Z"},
   "number-theory": {
-    "boring": {"type": "bool", "value": "false"},
+    "boring": {"type": "boolean", "value": "false"},
     "perfection": {
       "type": "array",
       "value": [

--- a/docs/json-encoding.md
+++ b/docs/json-encoding.md
@@ -1,0 +1,67 @@
+# JSON Encoding
+
+In this repository, `.json` files contain a JSON encoding of TOML data, as described below.
+
+## Description
+
+TOML tables encode to JSON Objects. TOML table arrays encode to JSON Array of Objects. TOML values are encoded as a JSON Object with the following structure:
+
+```json
+{
+  "type": "<type>",
+  "value": <value>
+}
+```
+
+`<type>` is one of:
+
+- `string`
+- `integer`
+- `float`
+- `boolean`
+- `offset datetime`
+- `local datetime`
+- `local date`
+- `local time`
+- `array`
+
+When `<type>` is an `array`, the `<value>` is a JSON array containing equivalent JSON encoding of the values of the TOML array. In all other cases, `<value>` is a JSON String.
+
+Note that the only JSON values ever used are Objects, Arrays and Strings.
+
+## Example
+
+```toml
+best-day-ever = 1987-07-05T17:45:00Z
+
+[number-theory]
+boring = false
+perfection = [6, 28, 496]
+```
+
+The JSON encoding for the above is:
+
+```json
+{
+  "best-day-ever": {"type": "datetime", "value": "1987-07-05T17:45:00Z"},
+  "number-theory": {
+    "boring": {"type": "bool", "value": "false"},
+    "perfection": {
+      "type": "array",
+      "value": [
+        {"type": "integer", "value": "6"},
+        {"type": "integer", "value": "28"},
+        {"type": "integer", "value": "496"}
+      ]
+    }
+  }
+}
+```
+
+## Why JSON?
+
+In order for a language agnostic test suite to work, we need some kind of data exchange format. TOML cannot be used, as it would imply that a particular parser has a blessing of correctness.
+
+JSON is a simple, well-established data exchange format. Support for JSON parsing is included in the standard library of many popular languages, and there are excellent libraries for other languages.
+
+The simplicity of JSON, however, creates a need for an encoding of TOML values (as described above). The explicit typing of TOML values in the JSON encoding is a good thing though, since it reduces the assumptions being made overall.

--- a/run.py
+++ b/run.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python
+"""TOML compliance suite runner.
+"""
+
+import argparse
+import difflib
+import json
+import multiprocessing
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+class Failed(Exception):
+    """Raised when a check fails for some reason
+
+    :param reason:
+        Textual reason, explaining why the test failed.
+    :param cause:
+        Exception, representing the reason for failure.
+    :param diff:
+        A tuple of 2 JSON-able objects, that should be presented as a diff.
+    """
+
+    def __init__(self, reason, *, cause=None, diff=None):
+        self.reason = reason
+
+        if cause is not None:
+            self.details = repr(cause)
+        elif diff is not None:
+            correct, got = diff
+            correct_str = json.dumps(correct, indent=2, sort_keys=True)
+            got_str = json.dumps(got, indent=2, sort_keys=True)
+
+            diff_lines = difflib.ndiff(
+                correct_str.splitlines(keepends=False),
+                got_str.splitlines(keepends=False),
+            )
+            self.details = "\n".join(diff_lines)
+        else:
+            self.details = None
+
+        super().__init__(reason, self.details)
+
+
+# --------------------------------------------------------------------------------------
+# Colors
+# --------------------------------------------------------------------------------------
+_COLOR_ALLOWED = sys.stdout.isatty()
+# Handle optional Windows-ANSI support dependency (colorama)
+if _COLOR_ALLOWED and os.name == "nt":
+    try:
+        import colorama
+    except ImportError:
+        print(
+            "TIP: If you install https://pypi.org/project/colorama, this program "
+            "will look much better."
+        )
+        _COLOR_ALLOWED = False
+    else:
+        colorama.init()
+
+_COLOR_NAMES = ["grey", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
+_COLOR_DICT = dict(zip(_COLOR_NAMES, range(8)))
+
+
+def colored(s, *, fg=None, bg=None, bold=False):
+    assert fg is not None or bg is not None
+    if not _COLOR_ALLOWED:
+        return s
+
+    ansi_codes = []
+    if bold:
+        ansi_codes.append(1)
+    if fg is not None:
+        ansi_codes.append(_COLOR_DICT[fg] + 30)
+    if bg is not None:
+        ansi_codes.append(_COLOR_DICT[bg] + 40)
+
+    parameters = ";".join(map(str, ansi_codes))
+
+    return f"\033[{parameters}m{s}\033[0m"
+
+
+# --------------------------------------------------------------------------------------
+# Filesystem interaction
+# --------------------------------------------------------------------------------------
+here = Path(__file__).parent
+
+
+def ensure_executable(path):
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Could not find file: {path}")
+    if not os.access(path, os.X_OK):
+        raise PermissionError(f"Not an executable file: {path}")
+
+
+def _locate_test_pairs():
+    for path in (here / "invalid").glob("*.toml"):
+        yield path, None
+    for path in (here / "invalid").glob("*.json"):
+        yield None, path
+
+    for path in (here / "valid").glob("*.toml"):
+        json_equivalent = path.with_suffix(".json")
+        assert json_equivalent.exists()
+        yield path, json_equivalent
+
+
+def _filter_based_on_markers(pairs, markers):
+    def marker_filter(pair):
+        # No filtering if no markers given.
+        if not markers:
+            return True
+
+        for m in markers:
+            # Matches the name of the file (allows -m array)
+            if m in pair[0].stem:
+                return True
+            # Matches the name of the parent folder (allows -m invalid)
+            if m == pair[0].parent.name:
+                return True
+        return False
+
+    yield from filter(marker_filter, pairs)
+
+
+def get_test_pairs(markers):
+    pairs = _locate_test_pairs()
+    yield from _filter_based_on_markers(pairs, markers)
+
+
+# --------------------------------------------------------------------------------------
+# Input / Output Handling
+# --------------------------------------------------------------------------------------
+def run_program(program, *, stdin, clean_exit):
+    try:
+        process = subprocess.run(
+            [program], input=stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+    except OSError as error:
+        raise Failed(f"could not run: {program}", cause=error)
+
+    # For invalid Test Cases
+    if clean_exit:
+        if process.returncode:
+            raise Failed(f"Got a non-zero exit code: {process.returncode}")
+        if process.stderr:
+            raise Failed(f"Got stderr output!", cause=process.stderr)
+    else:
+        if not process.returncode:
+            raise Failed("Should have rejected input.")
+
+    return process.stdout
+
+
+def load_json(*, content, source):
+    assert source in ["decoder's output", "test case input"]
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as error:
+        raise Failed(f"Could not parse {source} JSON", cause=error)
+
+    # TODO: validation and normalization?
+
+
+# --------------------------------------------------------------------------------------
+# Actual Compliance Checks
+# --------------------------------------------------------------------------------------
+def test_decoder(toml_file, json_file, clean_exit, decoder):
+    content = run_program(decoder, stdin=toml_file.read_bytes(), clean_exit=clean_exit)
+
+    # For valid Test Cases
+    correct_json = load_json(content=json_file.read_text(), source="test case input")
+    decoded_json = load_json(content=content, source="decoder's output")
+
+    if correct_json != decoded_json:
+        raise Failed(
+            "Mismatch between expected JSON and decoded JSON.",
+            diff=(correct_json, decoded_json),
+        )
+
+
+def test_encoder(json_file, clean_exit, encoder, decoder):
+    input_json = load_json(content=json_file.read_text(), source="test case input")
+
+    # Encode the input.
+    result = run_program(encoder, stdin=json_file.read_bytes(), clean_exit=clean_exit)
+
+    # Decode the result.
+    decoded = run_program(decoder, stdin=result, clean_exit=True)
+
+    # Check round-trip was same as original
+    round_trip_json = load_json(content=decoded, source="decoder's output")
+
+    if input_json != round_trip_json:
+        raise Failed(
+            "Mismatch between original JSON and encoded-decoded JSON.",
+            diff=(input_json, round_trip_json),
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Check Runners!
+# --------------------------------------------------------------------------------------
+def _show_summary(counts):
+    total = sum(counts.values())
+    if total == 0:
+        print(colored("Deselected all tests!", fg="red"))
+        return
+
+    n_passed = colored(
+        f"{counts['pass']} passed", fg="green" if counts["pass"] else "red"
+    )
+    n_total = f"{total} total"
+
+    print()
+    print("Summary: ", n_passed, ", ", n_total, sep="")
+
+
+def _show_pass(name):
+    print(colored(" PASS ", fg="grey", bg="green"), end=" ")
+    print(colored(name, fg="cyan"))
+
+
+def _show_fail(name, failed):
+    print(colored(" FAIL ", fg="grey", bg="red"), end=" ")
+    print(colored(name, fg="cyan"))
+
+    reason = textwrap.indent(failed.reason, "  ")
+    print(colored(reason, fg="red"))
+    if failed.details:
+        print(textwrap.indent(str(failed.details), "    "))
+
+
+# Those messy functions above, keeps this function clean.
+def run_with_reporting(function, checks):
+    counts = {"fail": 0, "pass": 0}
+
+    for name, kwargs in checks:
+        try:
+            function(**kwargs)
+        except Failed as e:
+            _show_fail(name, e)
+            counts["fail"] += 1
+        else:
+            _show_pass(name)
+            counts["pass"] += 1
+
+    _show_summary(counts)
+
+    # This will be the program's exit code
+    if counts["fail"] or sum(counts.values()) == 0:
+        return 1
+    return 0
+
+
+def encoder_compliance(encoder, decoder, markers):
+    def generate_parameters():
+        for toml_file, json_file in get_test_pairs(markers):
+            if json_file is None:  # need something to encode!
+                continue
+            yield (
+                json_file,
+                {
+                    "json_file": json_file,
+                    "clean_exit": toml_file is not None,
+                    "encoder": encoder,
+                    "decoder": decoder,
+                },
+            )
+
+    ensure_executable(encoder)
+    ensure_executable(decoder)
+
+    return run_with_reporting(test_encoder, generate_parameters())
+
+
+def decoder_compliance(decoder, markers):
+    def generate_parameters():
+        for toml_file, json_file in get_test_pairs(markers):
+            if toml_file is None:  # need something to decode!
+                continue
+            yield (
+                toml_file,
+                {
+                    "toml_file": toml_file,
+                    "clean_exit": json_file is not None,
+                    "json_file": json_file,
+                    "decoder": decoder,
+                },
+            )
+
+    ensure_executable(decoder)
+    return run_with_reporting(test_decoder, generate_parameters())
+
+
+# --------------------------------------------------------------------------------------
+# CLI argument handling
+# --------------------------------------------------------------------------------------
+def get_parser():
+    parser = argparse.ArgumentParser(prog="toml-compliance/run.py", allow_abbrev=False)
+    subparsers = parser.add_subparsers(title="commands")
+
+    encoder = subparsers.add_parser("encoder")
+    encoder.add_argument("target", action="store", help="Encoder to test")
+    encoder.add_argument(
+        "--decoder",
+        action="store",
+        help="Supporting decoder for testing",
+        required=True,
+    )
+    encoder.add_argument(
+        "-m",
+        metavar="MARKER",
+        dest="markers",
+        help="Only run tests that match given marker. Can be specified multiple times.",
+        nargs=1,
+    )
+
+    decoder = subparsers.add_parser("decoder")
+    decoder.add_argument("target", action="store", help="Encoder to test")
+    decoder.add_argument(
+        "-m",
+        metavar="MARKER",
+        dest="markers",
+        help="Only run tests that match given marker. Can be specified multiple times.",
+        nargs=1,
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+
+    if "target" not in args:
+        parser.print_help()
+        sys.exit(1)
+
+    # This check isn't super clear at first glance. It works since the 'decoder'
+    # subparser does not have a 'decoder' argument.
+    should_run_encoder_tests = "decoder" in args
+
+    if should_run_encoder_tests:
+        exit_code = encoder_compliance(args.target, args.decoder, args.markers)
+    else:
+        exit_code = decoder_compliance(args.target, args.markers)
+
+    sys.exit(exit_code)


### PR DESCRIPTION
Toward https://github.com/toml-lang/toml/issues/585.

This PR adds a nothing-other-than-Python-needed test runner, as well as documentation on how it can be used to run tests on an implementation. Let's add tests (and the validation for the JSON) in a follow up PRs.

For now, I really don't want to be sitting on this for much longer. :)
