### PR TITLE
Add "sub-categories" for tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,18 @@ Hello there! If you're reading this, you're likely implementing/maintain a TOML 
 
 For using this compliance test suite, to test a TOML decoder / encoder, a [specific interface](interfaces.md) to them needs to be provided. This interface (and test files themselves) utilize a [JSON encoding](json-encoding.md) of TOML documents.
 
+## Test Layout
+
+There are 2 categories of tests in this repository: valid and invalid.
+
+Valid tests check that a decoder (AKA parser) accepts valid TOML documents, and an encoder represents data correctly as TOML. Each valid tests consists of two files -- a `.toml` file containing a valid TOML document and a `.json` file containing the JSON encoding of that document.
+
+Invalid tests check that a decoder rejects invalid TOML data, and an encoder rejects data that can not be represented as TOML. An invalid test consist of a single `.toml` file (invalid TOML data, decoder) or a single `.json` file (invalid JSON encoding, encoder).
+
+Both the `valid/` and `invalid/` folders contain folders for sub-categories, based on which part of the TOML they are for (eg: array, int, float).
+
+The tests should be small enough that writing the JSON encoding by hand will not give you brain damage. The exact reverse is true when testing encoders.
+
 ## Usage
 
 > NOTE: If you're not able to use the provided runner for some technical reason, consider filing an issue. You can write your own test runner obviously, but that might be more work than necessary.
@@ -44,16 +56,6 @@ $ python run.py decoder <your-decoder> -m array -m invalid
 # run for all decoder tests, with "table" in their name
 $ python run.py decoder <your-decoder> -m table
 ```
-
-## Test Layout
-
-There are 2 kinds of tests in this repository: valid and invalid.
-
-Valid tests check that a decoder (AKA parser) accepts valid TOML documents, and an encoder represents data correctly as TOML. Each valid tests consists of two files -- a `.toml` file containing a valid TOML document and a `.json` file containing the JSON encoding of that document.
-
-Invalid tests check that a decoder rejects invalid TOML data, and an encoder rejects data that can not be represented as TOML. An invalid test consist of a single `.toml` file (invalid TOML data, decoder) or a single `.json` file (invalid JSON encoding, encoder).
-
-The tests should be small enough that writing the JSON encoding by hand will not give you brain damage. The exact reverse is true when testing encoders.
 
 ### Naming
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,15 +46,19 @@ The encoder tests require a specification-compliant decoder. The encoder's outpu
 
 ### Markers
 
-For both these commands, `-m` can be used to provide "markers" which are used to filter tests based on their category (`valid` or `invalid`) or names (good choices would be `array`, `table`, `unicode`). You may provide this option multiple times. A few examples:
+For both these commands, `-m` can be used to provide "markers" which are used to filter tests. Markers can match the overall category (`valid` or `invalid`), the sub-category they're in (like `array`, `int` ,`float`) or a part of the filename of the test (eg: `unicode`)
+
+A few examples:
 
 ```sh-session
 # run for all valid decoder tests
 $ python run.py decoder <your-decoder> -m valid
-# run for all invalid decoder tests, with "array" in their name
-$ python run.py decoder <your-decoder> -m array -m invalid
-# run for all decoder tests, with "table" in their name
+# run for all decoder tests, in the "table" subfolder
 $ python run.py decoder <your-decoder> -m table
+# run for all invalid decoder tests, in the "array" subfolder
+$ python run.py decoder <your-decoder> -m array -m invalid
+# run for all invalid decoder tests, with "unicode" in the filename
+$ python run.py decoder <your-decoder> -m unicode
 ```
 
 ### Naming

--- a/run.py
+++ b/run.py
@@ -98,12 +98,12 @@ def ensure_executable(path):
 
 
 def _locate_test_pairs():
-    for path in sorted((here / "invalid").glob("*.toml")):
+    for path in sorted((here / "invalid").glob("*/*.toml")):
         yield path, None
-    for path in sorted((here / "invalid").glob("*.json")):
+    for path in sorted((here / "invalid").glob("*/*.json")):
         yield None, path
 
-    for path in sorted((here / "valid").glob("*.toml")):
+    for path in sorted((here / "valid").glob("*/*.toml")):
         json_equivalent = path.with_suffix(".json")
         assert json_equivalent.exists(), f"Missing: {json_equivalent}"
         yield path, json_equivalent
@@ -116,11 +116,14 @@ def _filter_based_on_markers(pairs, markers):
             return True
 
         for m in markers:
-            # Matches the name of the file (allows -m array)
+            # Matches the name of the file (allows -m basic)
             if m in pair[0].stem:
                 return True
-            # Matches the name of the parent folder (allows -m invalid)
+            # Matches the name of the parent folder (allows -m array)
             if m == pair[0].parent.name:
+                return True
+            # Matches the name of the grandparent folder (allows -m invalid)
+            if m == pair[0].parent.parent.name:
                 return True
         return False
 

--- a/run.py
+++ b/run.py
@@ -98,12 +98,12 @@ def ensure_executable(path):
 
 
 def _locate_test_pairs():
-    for path in (here / "invalid").glob("*.toml"):
+    for path in sorted((here / "invalid").glob("*.toml")):
         yield path, None
-    for path in (here / "invalid").glob("*.json"):
+    for path in sorted((here / "invalid").glob("*.json")):
         yield None, path
 
-    for path in (here / "valid").glob("*.toml"):
+    for path in sorted((here / "valid").glob("*.toml")):
         json_equivalent = path.with_suffix(".json")
         assert json_equivalent.exists(), f"Missing: {json_equivalent}"
         yield path, json_equivalent


### PR DESCRIPTION
This is to require "valid/array/one.toml" instead of "valid/array-one.toml", making the folder trees easier to navigate once I add the tests.

This PR also updates how markers work and the relevant parts of the documentation.